### PR TITLE
Add Bash permissions to Claude GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,7 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          allowed_tools: "Bash"
           
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: "Bash"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Summary
- Enable Bash tool access for Claude in GitHub Actions workflows
- Update both `claude.yml` and `claude-code-review.yml` to include `allowed_tools: "Bash"`
- This resolves the issue where Claude cannot execute git commands or shell operations

## Test plan
- [ ] Verify Claude can execute bash commands in issue comments
- [ ] Verify Claude can execute bash commands in PR reviews
- [ ] Test with simple commands like `git status` or `ls`

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)