### PR TITLE
GitHub Actionsの権限エラーを修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## 概要
- Claude GitHub Actionsワークフローの認証エラーを修正
- `pull-requests`と`issues`の権限を`read`から`write`に変更
- 「User does not have write access on this repository」エラーを解決

## 変更内容
- `.github/workflows/claude.yml`: pull-requestsとissuesの権限をwriteに変更
- `.github/workflows/claude-code-review.yml`: pull-requestsとissuesの権限をwriteに変更

## テスト計画
- [ ] GitHub Actionsが権限エラーなしで実行されること
- [ ] ClaudeがイシューとPRにコメントを投稿できること
- [ ] コードレビューワークフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to allow write access for pull requests and issues in automated review processes. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->