### PR TITLE
fix: CodeRabbit設定ファイルのchatプロパティ解析エラーを修正

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,6 +32,8 @@ reviews:
 # Chat settings
 chat:
   # Chat inherits the language setting from the top-level language setting
+  auto_reply:
+    enabled: true
 
 # Set the tone of reviews
 tone_instructions: "Constructive and friendly"


### PR DESCRIPTION
## Summary
- CodeRabbit設定ファイル（.coderabbit.yaml）で発生していたchatプロパティの解析エラーを修正
- chatセクションにauto_replyプロパティを追加して有効なオブジェクト構造に変更
- これにより、CodeRabbitがデフォルト設定ではなく、正しく設定ファイルを読み込めるように

## User Request
.coderabbit.yamlの解析エラーを修正してほしい。エラー内容：「Validation error: Expected object, received null at "chat"」

## Impact
- CodeRabbitが設定ファイルを正しく読み込めるようになる
- 日本語でのコードレビューが適切に動作する
- デフォルト設定ではなく、カスタマイズした設定が適用される

## Why
CodeRabbitの設定ファイルにおいて、chatプロパティが空（null）として解釈されていたため、オブジェクトが期待される箇所で解析エラーが発生していた。YAMLの仕様上、コメントのみのセクションは有効な値を持たないため、エラーとなる。

## How
chatセクションに実際のプロパティ（auto_reply）を追加することで、有効なオブジェクト構造を持たせた。これにより、chatセクションが正しくオブジェクトとして認識される。

## What
`.coderabbit.yaml`ファイルのchatセクションに以下の変更を追加：
```yaml
chat:
  # Chat inherits the language setting from the top-level language setting
  auto_reply:
    enabled: true
```

## Technical Details
- YAMLパーサーはコメントのみのセクションをnullとして解釈する
- CodeRabbitの設定スキーマではchatプロパティにオブジェクトを期待
- auto_replyプロパティを追加することで有効なオブジェクト構造を提供

## Breaking Changes
なし。既存の動作に影響はなく、設定ファイルが正しく読み込まれるようになるのみ。

## Screenshots/Demo
N/A（設定ファイルの修正のため）

## Testing
- [ ] 修正後の.coderabbit.yamlファイルがYAMLとして有効であることを確認
- [ ] CodeRabbitが設定ファイルを正しく読み込むことを確認
- [ ] 日本語でのレビューが期待通り動作することを確認

## Review Points (check list)
- [ ] chatセクションの構造が適切か
- [ ] auto_replyプロパティの追加が妥当か
- [ ] 他に必要な設定プロパティがないか

## つらみ
YAMLのコメントのみのセクションがnullとして解釈される仕様により、一見すると有効に見える設定ファイルがエラーとなる。エラーメッセージからは具体的な修正方法が分かりにくく、試行錯誤が必要だった。

🤖 Generated with [Claude Code](https://claude.ai/code)