### PR TITLE
fix: GitHub Actionsワークフローの認証エラーを修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- GitHub Actionsでclaude-code-actionを使用する際の認証エラーを修正
- 両ワークフローファイルにgithub_tokenパラメータを追加
- これによりアクションがリポジトリへの必要な権限を取得できるようになる

## User Request
GitHub Actionsで以下のエラーが発生していたため修正を依頼された：
```
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
Error: Failed to setup GitHub token: Error: User does not have write access on this repository.
```

## Impact
- GitHub Actionsワークフローが正常に動作するようになる
- PRレビューやコメントへのClaude応答が正しく機能する
- 認証エラーによるワークフロー失敗が解消される

## Why
エラーメッセージから、`anthropics/claude-code-action@beta`アクションがリポジトリへの書き込み権限を持っていないことが原因と判断。github_tokenパラメータが欠落していることが根本原因と特定した。

## How
両方のGitHub Actionsワークフローファイルに`github_token: ${{ secrets.GITHUB_TOKEN }}`パラメータを追加することで、アクションが必要な権限を取得できるようにした。

## What
### 変更ファイル
1. `.github/workflows/claude-code-review.yml`
   - `github_token: ${{ secrets.GITHUB_TOKEN }}`を追加

2. `.github/workflows/claude.yml`
   - `github_token: ${{ secrets.GITHUB_TOKEN }}`を追加

## Technical Details
- GITHUB_TOKENはGitHub Actionsが自動的に提供するトークン
- このトークンはワークフロー実行時に必要な権限を持つ
- claude-code-actionがリポジトリへの書き込み権限を必要とするため、明示的な指定が必要

## Breaking Changes
なし

## Screenshots/Demo
該当なし

## Testing
- PRを作成後、GitHub Actionsの実行を確認
- 認証エラーが解消されることを確認

## Review Points (check list)
- [ ] 両ワークフローファイルにgithub_tokenが正しく追加されているか
- [ ] secrets.GITHUB_TOKENの参照が正しいか
- [ ] 他の設定に影響がないか

## つらみ
認証エラーのデバッグは実際にGitHub Actionsを実行してみないと確認できないため、試行錯誤が必要になることがある。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configurations to improve integration with automated code review tools. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->