### PR TITLE
fix: GitHub Actionsでブランチ作成権限エラーを修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
       ) && github.actor == 's4na'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
## Summary
- GitHub Actionsのclaude.ymlでcontents権限をreadからwriteに変更
- 「Resource not accessible by integration」エラーを解決
- ブランチ作成、コミット、プッシュなどのリポジトリ書き込み操作を可能に

## User Request
GitHub Actionsで「Resource not accessible by integration」エラーが発生し、ブランチ作成に失敗している問題を修正してください。

## Impact
- GitHub Actionsがissueやプルリクエストへのコメントに反応してブランチを作成できるようになります
- Claude Codeアクションが正常に動作し、コード変更を提案できるようになります

## Why
エラーメッセージとワークフローファイルを分析した結果、permissions設定でcontents権限がreadのみになっており、ブランチ作成に必要なwrite権限が不足していることが原因と判明しました。

## How
.github/workflows/claude.ymlのpermissions設定を更新し、contents権限をreadからwriteに変更しました。これにより、GitHub Actionsがリポジトリへの書き込み操作を実行できるようになります。

## What
### 変更内容
- `.github/workflows/claude.yml`: contents権限をreadからwriteに変更

## Technical Details
GitHub ActionsのIssue Commentトリガーでブランチを作成する際、`GITHUB_TOKEN`に適切な権限が必要です。デフォルトの権限では不足するため、明示的にcontents: writeを指定する必要があります。

## Breaking Changes
なし - 権限の追加のみで、既存の機能に影響はありません。

## Screenshots/Demo
該当なし

## Testing
- [ ] GitHub Actionsワークフローが正常に実行されることを確認
- [ ] Issue/PRコメントで@claudeメンションした際にブランチが作成されることを確認
- [ ] 権限エラーが発生しないことを確認

## Review Points (check list)
- [ ] permissions設定が適切に更新されているか
- [ ] 他のワークフローファイルでも同様の権限設定が必要ないか
- [ ] セキュリティ上の懸念がないか（write権限は最小限必要な範囲か）

## つらみ
GitHub Actionsの権限設定はエラーメッセージからは原因が分かりにくく、ドキュメントを読まないと適切な設定が分からないのがつらいです。特に「Resource not accessible by integration」というエラーメッセージは具体的にどの権限が不足しているのか明示されないため、トラブルシューティングに時間がかかります。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to improve automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->