### PR TITLE
fix: CodeRabbit設定ファイルのchat.auto_reply形式を修正

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,8 +32,7 @@ reviews:
 # Chat settings
 chat:
   # Chat inherits the language setting from the top-level language setting
-  auto_reply:
-    enabled: true
+  auto_reply: true
 
 # Set the tone of reviews
 tone_instructions: "Constructive and friendly"


### PR DESCRIPTION
## Summary

- CodeRabbit設定ファイルのパースエラーを修正
- `chat.auto_reply`の設定形式をオブジェクトからbooleanに変更

## User Request
CodeRabbitのパースエラーを解消するPRを作成して欲しい

## Impact
CodeRabbitのカスタム設定が正常に適用されるようになります。

## Why
`.coderabbit.yaml`ファイルで`chat.auto_reply`がオブジェクト形式で設定されており、CodeRabbitはboolean値を期待しているためパースエラーが発生していました。

## How
`chat.auto_reply`の設定を以下のように変更:
- 変更前: `auto_reply: { enabled: true }`
- 変更後: `auto_reply: true`

## What
`.coderabbit.yaml`の`chat.auto_reply`を直接的なboolean値に修正し、CodeRabbitの設定パースエラーを解消しました。

## Technical Details
- 修正ファイル: `.coderabbit.yaml`
- 修正行: 35-36行目
- エラー内容: "Expected boolean, received object at \"chat.auto_reply\""

## Breaking Changes
なし

## Screenshots/Demo
設定ファイルの修正のためスクリーンショットはありません。

## Testing
- [ ] 修正後にCodeRabbitのパースエラーが解消されることを確認

## Review Points (check list)
- [ ] `.coderabbit.yaml`の文法が正しいか確認
- [ ] `chat.auto_reply`がboolean値に設定されているか確認
- [ ] 他の設定項目に影響がないか確認

## つらみ
特にありません。単純な設定修正でした。

----

Closes #18

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * チャットの自動返信設定がシンプルな形式に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->